### PR TITLE
Gear Button Order Update

### DIFF
--- a/engine.html
+++ b/engine.html
@@ -118,39 +118,39 @@
             <li class="gamification-current" id="gamification-1">
               <button>1. Fuel</button>
             </li>
-            <li class="gamification-inactive" id="gamification-2">
-              <button>2. Oxidizer</button>
-            </li>
             <li class="gamification-inactive" id="gamification-3">
               <button>3. Oil</button>
-            </li>
-            <li class="gamification-inactive" id="gamification-4">
-              <button>4. Fuel Pump</button>
             </li>
             <li class="gamification-inactive" id="gamification-5">
               <button>5. Intake</button>
             </li>
-            <li class="gamification-inactive" id="gamification-6">
-              <button>6. Compression</button>
+            <li class="gamification-inactive" id="gamification-7">
+              <button>7. Spark</button>
+            </li>
+            <li class="gamification-inactive" id="gamification-9">
+              <button>9. Output Shaft</button>
+            </li>
+            <li class="gamification-inactive" id="gamification-11">
+              <button>11. Exhaust</button>
             </li>
           </ul>
         </section>
         <section class="game-buttons-right">
           <ul class="game-buttons">
-            <li class="gamification-inactive" id="gamification-7">
-              <button>7. Spark</button>
+            <li class="gamification-inactive" id="gamification-2">
+              <button>2. Oxidizer</button>
+            </li>
+            <li class="gamification-inactive" id="gamification-4">
+              <button>4. Fuel Pump</button>
+            </li>
+            <li class="gamification-inactive" id="gamification-6">
+              <button>6. Compression</button>
             </li>
             <li class="gamification-inactive" id="gamification-8">
               <button>8. Combustion</button>
             </li>
-            <li class="gamification-inactive" id="gamification-9">
-              <button>9. Output Shaft</button>
-            </li>
             <li class="gamification-inactive" id="gamification-10">
               <button>10. Gyroscope</button>
-            </li>
-            <li class="gamification-inactive" id="gamification-11">
-              <button>11. Exhaust</button>
             </li>
             <li class="gamification-inactive" id="gamification-12">
               <button>12. Valve Overlap</button>


### PR DESCRIPTION
This PR intruduces a fix to the order of the gear buttons on the engine page. Instead of two columns counting down, the buttons now appear in the correct zipper pattern order.